### PR TITLE
Refactor psql migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.o
 *.a
 *.so
+
+.idea
+fragmenta

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 Fragmenta is a command line tool for creating, managing and deploying golang web applications. It comes with a suite of libraries which making developing web apps easier, and aims to allow managing apps without making too many assumptions about which libraries they use or their internal structure. It takes care of generating CRUD actions, handling auth, routing and rendering and leaves you to concentrate the parts of your app which are unique. 
 
 ### Using Fragmenta
-
+(Fragmenta currently requires Postgres. You will need to setup a database user first. Use a command similar to:
+sudo -u postgres psql postgres -c "create user my_user with password 'my_password' CREATEDB;".
+Fragmenta will prompt for this database username and password when a new website is created)
 * fragmenta version -> display version
 * fragmenta help -> display help
 * fragmenta new [app|cms|blog|URL] path/to/app -> creates a new app from the repository at URL at the path supplied

--- a/README.md
+++ b/README.md
@@ -3,9 +3,15 @@
 Fragmenta is a command line tool for creating, managing and deploying golang web applications. It comes with a suite of libraries which making developing web apps easier, and aims to allow managing apps without making too many assumptions about which libraries they use or their internal structure. It takes care of generating CRUD actions, handling auth, routing and rendering and leaves you to concentrate the parts of your app which are unique. 
 
 ### Using Fragmenta
-(Fragmenta currently requires Postgres. You will need to setup a database user first. Use a command similar to:
-sudo -u postgres psql postgres -c "create user my_user with password 'my_password' CREATEDB;".
-Fragmenta will prompt for this database username and password when a new website is created)
+New projects must be generated within the $GOPATH tree.
+(Fragmenta is currently setup for Postgres. You will need to install Postgres (http://www.postgresql.org/download/linux/ubuntu/)
+and setup a database user first. Use a command similar to:
+
+    sudo -u postgres psql postgres -c "create user my_user with password 'my_password' CREATEDB;".
+Fragmenta will prompt for this database username and password when a new website is created.
+On Ubuntu, you may also need to edit `/etc/postgresql/9.4/main/pg_hba.conf`. Under the entry for *local* make sure the peer column is set to *password*
+)
+
 * fragmenta version -> display version
 * fragmenta help -> display help
 * fragmenta new [app|cms|blog|URL] path/to/app -> creates a new app from the repository at URL at the path supplied

--- a/fragmenta.go
+++ b/fragmenta.go
@@ -240,6 +240,21 @@ func runCommand(command string, args ...string) ([]byte, error) {
 	return output, nil
 }
 
+// runCommand runs a command with exec.Command
+func runCommandSetEnv(command string, p_env []string, args ...string) ([]byte, error) {
+	// It seems the only way to get env vars to exec is to set them manually here
+	for i := 0; i < len(p_env); i += 2 {
+		os.Setenv(p_env[i], p_env[i + 1])
+	}
+	cmd := exec.Command(command, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return output, err
+	}
+
+	return output, nil
+}
+
 // requireValidProject returns true if we have a valid project at projectPath
 func requireValidProject(projectPath string) bool {
 	if isValidProject(projectPath) {

--- a/fragmenta.go
+++ b/fragmenta.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// The version of this tool
-	fragmentaVersion = "1.3.1"
+	fragmentaVersion = "1.3.2.r"
 
 	// Used for outputting console messages
 	fragmentaDivider = "\n------\n"

--- a/migrate.go
+++ b/migrate.go
@@ -54,19 +54,21 @@ func migrateDB(config map[string]string) {
 		migrations = readMetadata()
 	}
 
+	perm_args := []string{"-U", config["db_user"], "-W"}
+
 	for _, file := range files {
 		filename := path.Base(file)
 
 		if !contains(filename, migrations) {
 			log.Printf("Running migration %s", filename)
 
-			args := []string{"-d", config["db"], "-f", file}
-			if strings.Contains(filename, createDatabaseMigrationName) {
-				args = []string{"-f", file}
+			args := append(perm_args, []string{"-f", file}...)
+			if !strings.Contains(filename, createDatabaseMigrationName) {
+				args = append(args, []string{"-d", config["db"]}...)
 				log.Printf("Running database creation migration: %s", file)
 			}
 
-			// Execute this sql file against the database
+			///fmt.Println("Args: %t", args)
 			result, err := runCommand("psql", args...)
 			if err != nil || strings.Contains(string(result), "ERROR") {
 				if err == nil {

--- a/new.go
+++ b/new.go
@@ -17,6 +17,7 @@ import (
 const (
 	createDatabaseMigrationName = "Create-Database"
 	createTablesMigrationName   = "Create-Tables"
+	appTemplateSource           = "github.com/rohanthewiz/"
 )
 
 // RunNew creates a new fragmenta project given the argument
@@ -46,11 +47,11 @@ func RunNew(args []string) {
 
 	switch repo {
 	case "app":
-		repo = "github.com/fragmenta/fragmenta-app"
+		repo = appTemplateSource + "fragmenta-app"
 	case "cms":
-		repo = "github.com/fragmenta/fragmenta-cms"
+		repo = appTemplateSource + "fragmenta-cms"
 	case "blog":
-		repo = "github.com/fragmenta/fragmenta-blog"
+		repo = appTemplateSource + "fragmenta-blog"
 	default:
 		// TODO clean repo if it contains https or .git...
 	}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,16 @@
+package main
+import (
+	"bufio"
+	"os"
+	"fmt"
+	"strings"
+)
+
+func promptForString(prompt string) (string, error) {
+	fmt.Printf("Enter %s: ", prompt)
+	text, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err == nil {
+		text = strings.TrimSpace(text)
+	}
+	return text, err
+}


### PR DESCRIPTION
Migrating a fresh postgres database errs out as psql was missing user credentials. Also a given user cannot run a migration to create the user (chicken and the egg situation). I solved the problem by creating the user in psql before the fragmenta migration and passing those creds into fragmenta new at a prompt.
