### PR TITLE
Make new command platform agnostic.

### DIFF
--- a/build.go
+++ b/build.go
@@ -58,6 +58,9 @@ func buildServer(server string, env []string) error {
 
 	// Add output location
 	args = append(args, `-o`)
+	if isWindows() {
+		server = server + ".exe"
+	}
 	args = append(args, server)
 
 	if localBuild {

--- a/build.go
+++ b/build.go
@@ -58,9 +58,6 @@ func buildServer(server string, env []string) error {
 
 	// Add output location
 	args = append(args, `-o`)
-	if isWindows() {
-		server = server + ".exe"
-	}
 	args = append(args, server)
 
 	if localBuild {

--- a/fragmenta.go
+++ b/fragmenta.go
@@ -169,12 +169,21 @@ func ShowHelp(args []string) {
 
 // serverName returns the name of our server file - TODO:read from config
 func serverName() string {
-	return "fragmenta-server" // for now, should use configs
+	name := "fragmenta-server"
+	if isWindows() {
+		name = name + ".exe"
+	}
+	return name // for now, should use configs
 }
 
 func localServerPath(projectPath string) string {
-	var servername = fmt.Sprintf("%s-local", serverName())
-	return filepath.Join(projectPath, "bin", servername)
+	name := serverName()
+	if isWindows() {
+		name = strings.Join(strings.Split(name, ".")[:1], "") + "-local.exe"
+	} else {
+		name = fmt.Sprintf("%s-local", name)
+	}
+	return filepath.Join(projectPath, "bin", name)
 }
 
 func serverPath(projectPath string) string {

--- a/fragmenta.go
+++ b/fragmenta.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 )
 
 const (
@@ -171,11 +173,12 @@ func serverName() string {
 }
 
 func localServerPath(projectPath string) string {
-	return fmt.Sprintf("%s/bin/%s-local", projectPath, serverName())
+	var servername = fmt.Sprintf("%s-local", serverName())
+	return filepath.Join(projectPath, "bin", servername)
 }
 
 func serverPath(projectPath string) string {
-	return fmt.Sprintf("%s/bin/%s", projectPath, serverName())
+	return filepath.Join(projectPath, "bin", serverName())
 }
 
 func serverCompilePath(projectPath string) string {
@@ -185,23 +188,38 @@ func serverCompilePath(projectPath string) string {
 // Return the src to scan assets for compilation
 // Can this be set within the project setup instead to avoid hardcoding here?
 func srcPath(projectPath string) string {
-	return projectPath + "src"
+	return filepath.Join(projectPath, "src")
 }
 
 func publicPath(projectPath string) string {
-	return projectPath + "public"
+	return filepath.Join(projectPath, "public")
 }
 
 func configPath(projectPath string) string {
-	return projectPath + "/secrets/fragmenta.json"
+	return filepath.Join(secretsPath(projectPath), "fragmenta.json")
 }
 
 func secretsPath(projectPath string) string {
-	return projectPath + "/secrets"
+	return filepath.Join(projectPath, "secrets")
 }
 
 func templatesPath() string {
-	return os.ExpandEnv("$GOPATH/src/github.com/fragmenta/fragmenta/templates")
+	path := filepath.Join("$GOPATH", "src", "github.com", "fragmenta", "fragmenta", "templates")
+	return os.ExpandEnv(path)
+}
+
+func dbMigratePath(projectPath string) string {
+	return filepath.Join(projectPath, "db", "migrate")
+}
+
+func dbBackupPath(projectPath string) string {
+	return filepath.Join(projectPath, "db", "backup")
+}
+
+func projectPathRelative(projectPath string) string {
+	goSrc := os.Getenv("GOPATH")
+	goSrc = filepath.Join(goSrc, "src")
+	return strings.Replace(projectPath, goSrc, "", 1)
 }
 
 // RunServer runs the server
@@ -307,4 +325,11 @@ func readConfig(projectPath string) error {
 	ConfigTest = data["test"]
 
 	return nil
+}
+
+func isWindows() bool {
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return false
 }

--- a/new.go
+++ b/new.go
@@ -233,11 +233,14 @@ func reifyNewSite(goProjectPath, projectPath string) error {
 func showNewSiteHelp(projectPath string) {
 	helpString := fragmentaDivider
 	helpString += "Congratulations, we've made a new website at " + projectPathRelative(projectPath)
-	helpString += "\n  if you wish you can edit the database config at secrets/fragmenta.json and sql at db/migrate"
+	helpString += "\n  if you wish you can edit the database config at:"
+	helpString += "\n    " + projectPathRelative(configPath(projectPath))
+	helpString += "\n  and sql at:"
+	helpString += "\n    " + projectPathRelative(dbMigratePath(projectPath))
 	helpString += "\n  To get started, run the following commands:"
-	helpString += "\n  cd " + projectPath
-	helpString += "\n  fragmenta migrate"
-	helpString += "\n  fragmenta"
+	helpString += "\n    cd " + projectPath
+	helpString += "\n    fragmenta migrate"
+	helpString += "\n    fragmenta"
 	helpString += fragmentaDivider + "\n"
 	fmt.Print(helpString) // fmt to avoid time output
 }
@@ -283,11 +286,6 @@ func generateCreateSQL(projectPath string) error {
 	}
 
 	return nil
-}
-
-func projectPathRelative(projectPath string) string {
-	goSrc := os.Getenv("GOPATH") + "/src/"
-	return strings.Replace(projectPath, goSrc, "", 1)
 }
 
 func generateConfig(projectPath string) error {


### PR DESCRIPTION
Note that I moved `projectPathRelative` from **new.go** to **fragmenta.go** where all the other project path functions are.